### PR TITLE
Add fraction support in unit specs and runtime input

### DIFF
--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -353,6 +353,28 @@ def test_round_trip(value, unit_a, unit_b):
     assert final == pytest.approx(value)
 
 
+# --- fraction support --------------------------------------------------------
+
+
+def test_parse_physical_quantity_fraction():
+    up = UnitParser()
+    qty, units = up._parse_physical_quantity('1/3 tablespoons')
+    assert qty == pytest.approx(1 / 3)
+    assert units == 'tablespoons'
+
+
+def test_convert_fraction_runtime_input():
+    """'1/3 tablespoons' should equal exactly 1 teaspoon."""
+    up = UnitParser()
+    assert up.convert('1/3 tablespoons', 'teaspoons') == pytest.approx(1.0)
+
+
+def test_teaspoon_exact_third():
+    """3 teaspoons should equal exactly 1 tablespoon (tight tolerance)."""
+    up = UnitParser()
+    assert up.convert('3 teaspoons', 'tablespoons') == pytest.approx(1.0, rel=1e-9)
+
+
 # --- case sensitivity --------------------------------------------------------
 
 

--- a/unit_parser/units.py
+++ b/unit_parser/units.py
@@ -2,6 +2,7 @@
 
 import re
 from dataclasses import dataclass
+from fractions import Fraction
 from pathlib import Path
 from typing import overload
 
@@ -156,13 +157,15 @@ class UnitParser:
 
         """
         double_re = r'[-+]?[0-9]*\.?[0-9]+'
+        fraction_re = r'[-+]?[0-9]+/[0-9]+'
+        number_re = r'(?:' + fraction_re + r'|' + double_re + r')'
         composite_unit_re = r'[a-zA-Z_]+'
         physical_quantity_re_with_names = (
-            r'(' + double_re + r')\s*(' + composite_unit_re + r')'
+            r'(' + number_re + r')\s*(' + composite_unit_re + r')'
         )
         result = re.match(physical_quantity_re_with_names, physical_quantity)
         if result:
-            quantity = float(result.group(1))
+            quantity = float(Fraction(result.group(1)))
             units = result.group(2)
             return quantity, units
         else:
@@ -214,6 +217,8 @@ class UnitParser:
         # This regular expression matches a double.
         # Source: http://www.regular-expressions.info/floatingpoint.html
         double_re = r'[-+]?[0-9]*\.?[0-9]+'
+        fraction_re = r'[-+]?[0-9]+/[0-9]+'
+        number_re = r'(?:' + fraction_re + r'|' + double_re + r')'
 
         # This regular expression represents a row vector, using Matlab
         # notation. Examples:
@@ -224,9 +229,10 @@ class UnitParser:
         # This regular expression represents a physical quantity. Examples:
         #   1 day
         #   60 seconds
-        physical_quantity_re = double_re + r'\s*' + composite_unit_re
+        #   1/3 tablespoons
+        physical_quantity_re = number_re + r'\s*' + composite_unit_re
         physical_quantity_re_with_names = (
-            r'(' + double_re + r')\s*(' + composite_unit_re + r')'
+            r'(' + number_re + r')\s*(' + composite_unit_re + r')'
         )
 
         # This regular expression represents a unit specification.
@@ -301,7 +307,7 @@ class UnitParser:
                 else:
                     result = re.match(physical_quantity_re_with_names, definition)
                     if result:
-                        this_quantity = float(result.group(1))
+                        this_quantity = float(Fraction(result.group(1)))
                         unit = result.group(2)
 
                         if this_quantity <= 0:

--- a/unit_parser/units/units.txt
+++ b/unit_parser/units/units.txt
@@ -156,7 +156,7 @@ tablespoon: 0.5 fluidOunces
 tablespoons: 1 tablespoon
 tbsp: 1 tablespoon
 
-teaspoon: 0.3333333 tablespoons
+teaspoon: 1/3 tablespoons
 teaspoons: 1 teaspoon
 tsp: 1 teaspoon
 


### PR DESCRIPTION
Extends the numeric parser in both _parse_unit_file and
_parse_physical_quantity to accept rational fractions (e.g. 1/3),
resolved via fractions.Fraction at parse time. Updates units.txt to use
the exact teaspoon: 1/3 tablespoons in place of the truncated decimal.

https://claude.ai/code/session_01V7Wthsu3jHzhidTPrWYC4G